### PR TITLE
rename module to go-libp2p-introspector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# GO-LIBP2P-INTROSPECTION
+# go-libp2p-introspector
 
-A go module allowing users to extract, stream and save data from their p2p peer
+A go module allowing users to extract, stream and save data from their p2p host.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libp2p/go-libp2p-introspection
+module github.com/libp2p/go-libp2p-introspector
 
 go 1.13
 

--- a/introspector.go
+++ b/introspector.go
@@ -1,4 +1,4 @@
-package introspection
+package introspector
 
 import (
 	"fmt"

--- a/ws_server.go
+++ b/ws_server.go
@@ -1,4 +1,4 @@
-package introspection
+package introspector
 
 import (
 	"errors"

--- a/ws_server_test.go
+++ b/ws_server_test.go
@@ -1,4 +1,4 @@
-package introspection
+package introspector
 
 import (
 	"fmt"


### PR DESCRIPTION
Something felt wrong with the name. I think this fixes it. Rationale:

* `go-libp2p-core/introspection` => the package that defines the semantics and abstractions for the introspection capability.
* `go-libp2p-introspector` => the component/actor that materially performs the introspection, i.e. the introspector.